### PR TITLE
fix(playback): resolve relative local paths against cwd (#18)

### DIFF
--- a/music_cli/cli.py
+++ b/music_cli/cli.py
@@ -289,6 +289,25 @@ def _detect_play_mode(source_arg):
     return "radio", source_arg
 
 
+def _resolve_local_path(source: str) -> str:
+    """Resolve a local playback source against the CLI's cwd.
+
+    The daemon is a long-running background process started once with its
+    own cwd (see start_daemon_background) — it is generally not the cwd of
+    the terminal a later `play` command runs in. A still-relative path
+    handed to the daemon therefore gets checked against the *daemon's* cwd,
+    not the user's, and silently misses even when the file is right there.
+    Resolve it to an absolute path here, while we still have the correct
+    cwd, so it survives the trip over IPC unchanged. Leave anything that
+    doesn't exist relative to cwd as-is so the daemon's fallback to the
+    configured music directory keeps working.
+    """
+    path = Path(source)
+    if not path.is_absolute() and path.exists():
+        return str(path.resolve())
+    return source
+
+
 @main.command()
 @click.argument("source", required=False, default=None)
 @click.option(
@@ -365,6 +384,11 @@ def play(source, mode, source_flag, mood, auto, duration, index):
         effective_source = detected_source
     # If mode was explicitly given, keep the old behaviour
     # (effective_source from flag/positional is used as-is)
+
+    # Issue #18: a relative local path must be resolved before it crosses
+    # the IPC boundary to the daemon (see _resolve_local_path).
+    if mode == "local" and effective_source:
+        effective_source = _resolve_local_path(effective_source)
 
     client = ensure_daemon()
 

--- a/music_cli/sources/local.py
+++ b/music_cli/sources/local.py
@@ -23,8 +23,14 @@ class LocalSource:
         file_path = Path(path)
 
         if not file_path.is_absolute():
-            # Try relative to music dir
-            file_path = self.music_dir / file_path
+            # Prefer a match relative to the current working directory;
+            # resolve it now so the result doesn't depend on cwd staying
+            # the same for the rest of the call chain (e.g. across the
+            # daemon's IPC boundary). Fall back to the configured music dir.
+            if file_path.exists():
+                file_path = file_path.resolve()
+            else:
+                file_path = self.music_dir / file_path
 
         if not file_path.exists():
             return None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,12 +1,13 @@
 """Tests for CLI v2 Phase 1, Phase 2 & Phase 3."""
 
 import os
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
 
-from music_cli.cli import _detect_play_mode, icon, main
+from music_cli.cli import _detect_play_mode, _resolve_local_path, icon, main
 
 
 @pytest.fixture
@@ -379,6 +380,90 @@ class TestSmartPlayDetection:
         assert result.exit_code == 0
         call_kwargs = mock_daemon_client.play.call_args
         assert call_kwargs[1]["mode"] == "context" or call_kwargs.kwargs["mode"] == "context"
+
+
+class TestResolveLocalPath:
+    """Unit tests for _resolve_local_path (issue #18)."""
+
+    def test_relative_existing_path_resolved_to_absolute(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        f = Path("song.mp3")
+        f.touch()
+
+        resolved = _resolve_local_path("song.mp3")
+
+        assert resolved == str((tmp_path / "song.mp3").resolve())
+
+    def test_relative_missing_path_returned_unchanged(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+
+        resolved = _resolve_local_path("missing.mp3")
+
+        assert resolved == "missing.mp3"
+
+    def test_absolute_path_returned_unchanged(self, tmp_path):
+        f = tmp_path / "song.mp3"
+        f.touch()
+
+        resolved = _resolve_local_path(str(f))
+
+        assert resolved == str(f)
+
+
+class TestPlayRelativeLocalPath:
+    """`mc play <relative-file>` must send the daemon an absolute path.
+
+    The daemon is a separate long-running process — a relative path sent
+    as-is would be checked against the *daemon's* cwd, not the terminal's,
+    and would silently fail to be found (issue #18).
+    """
+
+    @patch("music_cli.cli.ensure_daemon")
+    @patch("music_cli.cli.check_ffplay_available", return_value=True)
+    def test_play_relative_file_sends_absolute_source(
+        self, mock_ffplay, mock_daemon, runner, mock_daemon_client, tmp_path, monkeypatch
+    ):
+        monkeypatch.chdir(tmp_path)
+        Path("song.mp3").touch()
+        mock_daemon.return_value = mock_daemon_client
+
+        result = runner.invoke(main, ["play", "song.mp3"])
+
+        assert result.exit_code == 0
+        call_kwargs = mock_daemon_client.play.call_args.kwargs
+        assert call_kwargs["mode"] == "local"
+        assert call_kwargs["source"] == str((tmp_path / "song.mp3").resolve())
+
+    @patch("music_cli.cli.ensure_daemon")
+    @patch("music_cli.cli.check_ffplay_available", return_value=True)
+    def test_play_explicit_mode_local_relative_file_sends_absolute_source(
+        self, mock_ffplay, mock_daemon, runner, mock_daemon_client, tmp_path, monkeypatch
+    ):
+        monkeypatch.chdir(tmp_path)
+        Path("song.mp3").touch()
+        mock_daemon.return_value = mock_daemon_client
+
+        result = runner.invoke(main, ["play", "song.mp3", "--mode", "local"])
+
+        assert result.exit_code == 0
+        call_kwargs = mock_daemon_client.play.call_args.kwargs
+        assert call_kwargs["source"] == str((tmp_path / "song.mp3").resolve())
+
+    @patch("music_cli.cli.ensure_daemon")
+    @patch("music_cli.cli.check_ffplay_available", return_value=True)
+    def test_play_explicit_mode_local_missing_file_kept_relative(
+        self, mock_ffplay, mock_daemon, runner, mock_daemon_client, tmp_path, monkeypatch
+    ):
+        # Not found in cwd -> left unchanged so the daemon still falls back
+        # to the configured music directory (today's behavior, preserved).
+        monkeypatch.chdir(tmp_path)
+        mock_daemon.return_value = mock_daemon_client
+
+        result = runner.invoke(main, ["play", "not-in-cwd.mp3", "--mode", "local"])
+
+        assert result.exit_code == 0
+        call_kwargs = mock_daemon_client.play.call_args.kwargs
+        assert call_kwargs["source"] == "not-in-cwd.mp3"
 
 
 # -------------------------------------------------------------------------

--- a/tests/test_local_source.py
+++ b/tests/test_local_source.py
@@ -1,0 +1,88 @@
+"""Tests for LocalSource relative-path resolution (issue #18)."""
+
+from music_cli.sources.local import LocalSource
+
+
+class TestGetTrackRelativePaths:
+    """get_track() should check the current working directory before
+    falling back to the configured music directory."""
+
+    def test_relative_path_found_in_cwd(self, tmp_path, monkeypatch):
+        cwd = tmp_path / "cwd"
+        music_dir = tmp_path / "music"
+        cwd.mkdir()
+        music_dir.mkdir()
+        (cwd / "song.mp3").touch()
+        monkeypatch.chdir(cwd)
+
+        source = LocalSource(music_dir=music_dir)
+        track = source.get_track("song.mp3")
+
+        assert track is not None
+        assert track.title == "song"
+        assert track.source == str((cwd / "song.mp3").resolve())
+
+    def test_relative_path_falls_back_to_music_dir(self, tmp_path, monkeypatch):
+        cwd = tmp_path / "cwd"
+        music_dir = tmp_path / "music"
+        cwd.mkdir()
+        music_dir.mkdir()
+        (music_dir / "song.mp3").touch()
+        monkeypatch.chdir(cwd)
+
+        source = LocalSource(music_dir=music_dir)
+        track = source.get_track("song.mp3")
+
+        assert track is not None
+        assert track.source == str(music_dir / "song.mp3")
+
+    def test_relative_path_not_found_anywhere_returns_none(self, tmp_path, monkeypatch):
+        cwd = tmp_path / "cwd"
+        music_dir = tmp_path / "music"
+        cwd.mkdir()
+        music_dir.mkdir()
+        monkeypatch.chdir(cwd)
+
+        source = LocalSource(music_dir=music_dir)
+        track = source.get_track("missing.mp3")
+
+        assert track is None
+
+    def test_cwd_match_takes_priority_over_music_dir(self, tmp_path, monkeypatch):
+        cwd = tmp_path / "cwd"
+        music_dir = tmp_path / "music"
+        cwd.mkdir()
+        music_dir.mkdir()
+        (cwd / "song.mp3").touch()
+        (music_dir / "song.mp3").touch()
+        monkeypatch.chdir(cwd)
+
+        source = LocalSource(music_dir=music_dir)
+        track = source.get_track("song.mp3")
+
+        assert track.source == str((cwd / "song.mp3").resolve())
+
+    def test_absolute_path_unaffected(self, tmp_path):
+        music_dir = tmp_path / "music"
+        music_dir.mkdir()
+        f = music_dir / "song.mp3"
+        f.touch()
+
+        source = LocalSource(music_dir=tmp_path / "other")
+        track = source.get_track(str(f))
+
+        assert track is not None
+        assert track.source == str(f)
+
+    def test_unsupported_extension_in_cwd_returns_none(self, tmp_path, monkeypatch):
+        cwd = tmp_path / "cwd"
+        music_dir = tmp_path / "music"
+        cwd.mkdir()
+        music_dir.mkdir()
+        (cwd / "notes.txt").touch()
+        monkeypatch.chdir(cwd)
+
+        source = LocalSource(music_dir=music_dir)
+        track = source.get_track("notes.txt")
+
+        assert track is None


### PR DESCRIPTION
Closes #18

## Summary

`mc play song.mp3` failed to find a file sitting right in the current directory and fell back to "Could not find track to play." The fix resolves an existing relative local path to an absolute path on the client side, before it crosses the daemon's IPC boundary, and hardens `LocalSource.get_track()` to check the working directory before falling back to the configured music directory.

## Approach

Direct minimal fix, scoped to the two places the relative path is actually evaluated. No refactor of the surrounding CLI/daemon plumbing.

## Decision Record

- **Root cause:** `mc play` is a client for a long-running background daemon (`music_cli/daemon.py`) reached over a Unix-domain-socket IPC boundary. The daemon's cwd is whatever it was when it was first spawned (`start_daemon_background` in `cli.py`, no explicit `cwd=`) — it is not the terminal's cwd for a later `play` invocation. `cli.py`'s `_detect_play_mode` already checks `Path(source_arg).exists()` correctly (client-side, correct cwd) but then forwarded the original *unresolved* relative string to the daemon. By the time `LocalSource.get_track()` ran inside the daemon, `Path("song.mp3").exists()` was being evaluated against the daemon's cwd, not the caller's — so a file that plainly exists in the terminal's cwd was reported missing, and playback silently fell through to `~/Music`.
- **Options considered:** Option 1 — apply only the issue's literal suggested patch to `LocalSource.get_track()`; Option 2 — resolve the relative path client-side in `cli.py` before it crosses the IPC boundary, plus harden `get_track()` for direct callers; Option 3 — teach the daemon protocol a new "client cwd" field and resolve inside the daemon.
- **Options rejected:** Option 1 — verified against the actual daemon architecture (see Root cause) this does not fix the reported bug at all: `get_track()` runs in the daemon process, which has the wrong cwd, so the check would still miss the file in the real `mc play` flow; Option 3 — a protocol change for something the client can already resolve correctly itself is unnecessary surface area for this bug.
- **Selected option:** Option 2 — resolve in the client where the correct cwd is available, and keep `LocalSource.get_track()` correct in isolation for any non-daemon caller.
- **Residual risk:** None identified. Absolute paths and relative paths not found in cwd are left byte-for-byte unchanged, so existing behavior (including the `~/Music` fallback) is preserved.
- **Reproduction:** Verified red — `tests/test_local_source.py::TestGetTrackRelativePaths::test_relative_path_found_in_cwd` and `::test_cwd_match_takes_priority_over_music_dir` fail against pre-fix `music_cli/sources/local.py` (`assert track is not None` → `AssertionError: assert None is not None`), and `tests/test_cli.py` fails to collect entirely against pre-fix `cli.py` (`_resolve_local_path` doesn't exist yet) — confirmed by temporarily stashing the fix and re-running the suite → fixed → regression tests `tests/test_local_source.py` (6 cases) and `tests/test_cli.py::TestResolveLocalPath` / `::TestPlayRelativeLocalPath` (6 cases).

Analyzed at: `fix/18-relative-path-playback @ 616b140` (2026-07-23)

## Changes

| File | Change |
|------|--------|
| `music_cli/cli.py` | Add `_resolve_local_path()`; call it in `play()` for `mode == "local"` (covers both auto-detected and explicit `--mode local`) so an existing relative path is resolved to absolute before it's sent to the daemon |
| `music_cli/sources/local.py` | `get_track()` now checks the relative path against cwd (resolving to absolute if found) before falling back to `self.music_dir` |
| `tests/test_local_source.py` | New — unit tests for `LocalSource.get_track()` cwd-first resolution, music_dir fallback, priority ordering, not-found, unsupported extension, and absolute-path passthrough |
| `tests/test_cli.py` | New tests for `_resolve_local_path()` and for `play()` sending an absolute `source` to the (mocked) daemon for both auto-detected and explicit `--mode local` relative paths, plus the not-found-in-cwd fallback |

## Test Results

- Unit tests: 347 passed (full suite; 12 new)
- Integration tests: included above (`tests/test_e2e.py`, no live daemon required)
- E2e tests: included above
- Build: n/a (no build step)
- Lint/type/security: `ruff check`, `ruff format --check`, `mypy --ignore-missing-imports`, `bandit -c pyproject.toml -r` all clean on changed files
- QA cycles: 1 (independent code-review pass — PASS, 0 issues)

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| `mc play <relative-file>` finds a file in the current working directory | pass | Verified red: `tests/test_cli.py::TestPlayRelativeLocalPath::test_play_relative_file_sends_absolute_source` (fails to collect pre-fix — `_resolve_local_path` missing) → fixed → passes; daemon now receives an absolute path regardless of its own cwd |
| Falls back to the configured music directory (`~/Music`) when not found in cwd | pass | `tests/test_local_source.py::test_relative_path_falls_back_to_music_dir` and `tests/test_cli.py::TestPlayRelativeLocalPath::test_play_explicit_mode_local_missing_file_kept_relative` — existing fallback behavior unchanged |
| Backward-compatible — doesn't break existing absolute-path / non-local playback | pass | `tests/test_local_source.py::test_absolute_path_unaffected`, `tests/test_cli.py::TestResolveLocalPath::test_absolute_path_returned_unchanged`; full pre-existing suite (335 prior tests) still passes unmodified |
